### PR TITLE
Ensure imeHeight is always positive

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/safearea/SafeArea.kt
+++ b/android/src/main/java/com/getcapacitor/community/safearea/SafeArea.kt
@@ -88,7 +88,10 @@ class SafeArea(private val activity: Activity, private val webView: WebView) {
 
             // To get the actual height of the keyboard, we need to subtract the height of the system bars from the height of the ime
             // Source: https://stackoverflow.com/a/75328335/8634342
-            val imeHeight = imeInsets.bottom - systemBarsInsets.bottom
+            var imeHeight = imeInsets.bottom - systemBarsInsets.bottom
+            if (imeHeight < 0) {
+                imeHeight = 0
+            }
 
             // Set padding of decorview so the scroll view stays correct.
             // Otherwise the content behind the keyboard cannot be viewed by the user.


### PR DESCRIPTION
Ensure the imeHeight is always positive. This will keep the activity above or at the bottom of the decor view

This should fix issue #24.