### PR TITLE
Fix IME paddings

### DIFF
--- a/android/src/main/java/com/getcapacitor/community/safearea/SafeArea.kt
+++ b/android/src/main/java/com/getcapacitor/community/safearea/SafeArea.kt
@@ -4,6 +4,7 @@ import android.app.Activity
 import android.graphics.Color
 import android.view.WindowManager
 import android.webkit.WebView
+import android.widget.FrameLayout
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
@@ -95,9 +96,14 @@ class SafeArea(private val activity: Activity, private val webView: WebView) {
             }
             setProperty("right", Math.round(systemBarsInsets.right / density))
 
-            // Set padding of decorview so the scroll view stays correct.
-            // Otherwise the content behind the keyboard cannot be viewed by the user
-            activity.window.decorView.setPadding(0, 0, 0, imeInsets.bottom)
+            // Set padding so the scroll view stays correct.
+            // Otherwise the content behind the keyboard cannot be viewed by the user.
+            // The padding has to be set to the "content" view and not decor view as decor view includes the navigation bar background,
+            // which would then get pushed above the keyboard.
+            val contentView =
+                activity.window.decorView.findViewById<FrameLayout>(android.R.id.content)
+                    .getChildAt(0)
+            contentView.setPadding(0, 0, 0, imeInsets.bottom)
         }
     }
 

--- a/android/src/main/java/com/getcapacitor/community/safearea/SafeArea.kt
+++ b/android/src/main/java/com/getcapacitor/community/safearea/SafeArea.kt
@@ -95,13 +95,9 @@ class SafeArea(private val activity: Activity, private val webView: WebView) {
             }
             setProperty("right", Math.round(systemBarsInsets.right / density))
 
-            // To get the actual height of the keyboard, we need to subtract the height of the system bars from the height of the ime
-            // Source: https://stackoverflow.com/a/75328335/8634342
-            val imeHeight = (imeInsets.bottom - systemBarsInsets.bottom).coerceAtLeast(0)
-
             // Set padding of decorview so the scroll view stays correct.
-            // Otherwise the content behind the keyboard cannot be viewed by the user.
-            activity.window.decorView.setPadding(0, 0, 0, imeHeight)
+            // Otherwise the content behind the keyboard cannot be viewed by the user
+            activity.window.decorView.setPadding(0, 0, 0, imeInsets.bottom)
         }
     }
 


### PR DESCRIPTION
This reverts commit acfaa0cda35792e10fd1a67e711af582d633261f and fixes #38.

Overall this PR has 2 separate parts:
1. Revert of acfaa0cda35792e10fd1a67e711af582d633261f. The [Stackoverflow thread](https://stackoverflow.com/questions/75325095/how-to-use-windowinsetscompat-correctly-to-listen-to-keyboard-height-change-in-a/75328335#75328335) mentioned in the original code does provide what it says on the tin - a way to get the height of just the keyboard, but in the case of this plugin that isn't the desired value, the bottom inset needs to be both the keyboard height and the navbar height together, otherwise content will be partially underneath the keyboard.
2. A change of which View the IME padding is applied to. If applied to the decor view it pushes any existing navigation bar background above the keyboard (and over the app's content).

I've tested this on several devices and android versions (11, 14, 15, though of course all on targetSdk 34), but only one app. So if there's anyone for whom alpha.8 worked correctly, there's gotta be something else in how our respective apps are configured, but I really can't think of anything that could do that. 