### PR TITLE
Add imports to EdgeToEdge enable instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ The plugin itself is enabled automatically. Additionally, you should enable nati
 Java:
 
 ```java
+import android.os.Bundle;
+import com.getcapacitor.BridgeActivity;
+import androidx.activity.EdgeToEdge;
+
 public class MainActivity extends BridgeActivity {
     @Override
     public void onCreate(Bundle savedInstanceState) {
@@ -63,6 +67,11 @@ public class MainActivity extends BridgeActivity {
 Kotlin:
 
 ```kotlin
+
+import android.os.Bundle;
+import com.getcapacitor.BridgeActivity;
+import androidx.activity.EdgeToEdge;
+
 class MainActivity : BridgeActivity() {
     public override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ public class MainActivity extends BridgeActivity {
 Kotlin:
 
 ```kotlin
-
 import android.os.Bundle;
 import com.getcapacitor.BridgeActivity;
 import androidx.activity.EdgeToEdge;


### PR DESCRIPTION
To an Android noob like me, it was not clear that the setup instructions to enable `EdgeToEdge` required some extra imports, so I got failing builds until I figured it out.

This adds those imports explicitly to the instructions.